### PR TITLE
✨ Add chart view for balance history

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,33 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": ".NET Core Launch (web)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/ChildAllowanceManager/bin/Debug/net8.0/ChildAllowanceManager.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/ChildAllowanceManager",
+            "stopAtEntry": false,
+            "serverReadyAction": {
+                "action": "openExternally",
+                "pattern": "\\bNow listening on:\\s+(https?://\\S+)"
+            },
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            },
+            "sourceFileMap": {
+                "/Views": "${workspaceFolder}/Views"
+            }
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach"
+        }
+    ]
+}

--- a/ChildAllowanceManager.Common/Interfaces/ITransactionService.cs
+++ b/ChildAllowanceManager.Common/Interfaces/ITransactionService.cs
@@ -21,5 +21,5 @@ public interface ITransactionService
     ValueTask<AllowanceTransaction?> GetLatestRegularTransactionForChild(string childId, string tenantId, CancellationToken cancellationToken = default);
     ValueTask<AllowanceTransaction?> GetLatestTransactionForChild(string childId, string tenantId, CancellationToken cancellationToken = default);
 
-    
+    ValueTask<IEnumerable<BalanceHistoryEntry>> GetBalanceHistoryForChild(string childId, string tenantId, DateTimeOffset? startDate, DateTimeOffset? endDate, CancellationToken cancellationToken);
 }

--- a/ChildAllowanceManager.Common/Models/BalanceHistoryEntry.cs
+++ b/ChildAllowanceManager.Common/Models/BalanceHistoryEntry.cs
@@ -1,0 +1,3 @@
+namespace ChildAllowanceManager.Common.Models;
+
+public record BalanceHistoryEntry(DateTimeOffset Timestamp, decimal Balance);

--- a/ChildAllowanceManager.Common/Models/ChildWithBalanceHistory.cs
+++ b/ChildAllowanceManager.Common/Models/ChildWithBalanceHistory.cs
@@ -1,0 +1,3 @@
+namespace ChildAllowanceManager.Common.Models;
+
+public record ChildWithBalanceHistory(string ChildId, string TenantId, BalanceHistoryEntry[] BalanceHistory);

--- a/ChildAllowanceManager/Components/ChildTransactionsTable.razor
+++ b/ChildAllowanceManager/Components/ChildTransactionsTable.razor
@@ -4,7 +4,6 @@
 
 <div>
 <MudTable @ref="@_table" 
-          Items="@_transactions" 
           RowsPerPage="25" 
           Hover="true" 
           Breakpoint="Breakpoint.Sm" 

--- a/ChildAllowanceManager/Components/Pages/ChildrenListPage.razor
+++ b/ChildAllowanceManager/Components/Pages/ChildrenListPage.razor
@@ -26,35 +26,51 @@
                 }
             </MudCardHeader>
             <MudCardContent>
-                <MudText Typo="Typo.h4" 
-                         Color="@(child.Balance > 0 ? Color.Success : Color.Error)"
-                         Class="mb-2 pb-2">@child.Balance.ToString("C2")</MudText>
-                @if (child.HoldDaysRemaining > 0)
-                {
-                    <MudChipSet T="string">
-                        @for (int i = 0; i < child.HoldDaysRemaining; i++)
+                <MudGrid>
+                    <MudItem xs="12" sm="6" md="3">
+                        <MudText Typo="Typo.h4" 
+                                Color="@(child.Balance > 0 ? Color.Success : Color.Error)"
+                                Class="mb-2 pb-2">@child.Balance.ToString("C2")</MudText>
+                        @if (child.HoldDaysRemaining > 0)
                         {
-                            <AuthorizeView Roles="admin,parent">
-                                <Authorized>
-                                    <MudChip Icon="fa-solid fa-ban"
-                                             IconColor="Color.Error"
-                                             Class="ma-2 px-3"
-                                             OnClose="() => RemoveHoldDay(child)"
-                                             T="string"/>
-                                </Authorized>
-                                <NotAuthorized>
-                                    <MudChip Icon="fa-solid fa-ban"
-                                             IconColor="Color.Error"
-                                             Variant="Variant.Outlined"
-                                             Class="ma-2 px-1"
-                                             T="string"/>
-                                </NotAuthorized>
-                            </AuthorizeView>
+                            <MudChipSet T="string">
+                                @for (int i = 0; i < child.HoldDaysRemaining; i++)
+                                {
+                                    <AuthorizeView Roles="admin,parent">
+                                        <Authorized>
+                                            <MudChip Icon="fa-solid fa-ban"
+                                                    IconColor="Color.Error"
+                                                    Class="ma-2 px-3"
+                                                    OnClose="() => RemoveHoldDay(child)"
+                                                    T="string"/>
+                                        </Authorized>
+                                        <NotAuthorized>
+                                            <MudChip Icon="fa-solid fa-ban"
+                                                    IconColor="Color.Error"
+                                                    Variant="Variant.Outlined"
+                                                    Class="ma-2 px-1"
+                                                    T="string"/>
+                                        </NotAuthorized>
+                                    </AuthorizeView>
+                                }
+                            </MudChipSet>
                         }
-                    </MudChipSet>
-                }
-                <MudText Typo="Typo.body1">+@child.NextRegularChange.ToString("C2") @child.NextRegularChangeDate.ToLocalTime().Humanize()</MudText>
-                
+                        <MudText Typo="Typo.body1">+@child.NextRegularChange.ToString("C2") @child.NextRegularChangeDate.ToLocalTime().Humanize()</MudText>
+                    </MudItem>
+                    <MudItem xs="12" sm="6" md="9" Class="d-flex align-stretch ma-0 pa-0" Style="height: 100%;width: 100%;">
+                        <MudChart ChartType="ChartType.Line"
+                                    ChartSeries="@(new[] { ChildBalanceHistorySeries.GetValueOrDefault(child.Id) }.ToList())"
+                                    Width="100%"
+                                    
+                                    ChartOptions="@(new ChartOptions { 
+                                        ChartPalette = ["red"], 
+                                        ShowLegend = false,
+                                        LineStrokeWidth = 5,
+                                        YAxisFormat = "C"
+                                    })">
+                        </MudChart>
+                    </MudItem>
+                </MudGrid>
             </MudCardContent>
             <MudCardActions>
                 <MudTooltip Text="Transactions">


### PR DESCRIPTION
- Introduce `BalanceHistoryEntry` and `ChildWithBalanceHistory` models to represent balance history data.
- Implement `GetBalanceHistoryForChild` method in `TransactionService` to retrieve balance history for a specific child.
- Update `DataService` to include `GetChildrenWithBalanceHistory` method for fetching children along with their balance history.
- Modify `ChildrenListPage` to display balance history in a chart alongside child details.
- Create a new `.vscode/launch.json` file for debugging configuration.

These changes enhance the application by providing users with insight into children's balance history, improving data visibility and user experience.