### PR TITLE
Restructure tests with MTP, Shouldly, and bUnit coverage

### DIFF
--- a/ChildAllowanceManager.CosmosDbTests/ChildAllowanceManager.CosmosDbTests.csproj
+++ b/ChildAllowanceManager.CosmosDbTests/ChildAllowanceManager.CosmosDbTests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AspNetCore.HealthChecks.CosmosDb" Version="8.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.Testing.Platform" Version="1.4.1" />
+    <PackageReference Include="Microsoft.Testing.Platform.MSBuild" Version="1.4.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Shouldly" Version="4.2.1" />
+    <PackageReference Include="Testcontainers" Version="4.5.0" />
+    <PackageReference Include="Testcontainers.CosmosDb" Version="4.5.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ChildAllowanceManager\ChildAllowanceManager.csproj" />
+    <ProjectReference Include="..\ChildAllowanceManager.Common\ChildAllowanceManager.Common.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ChildAllowanceManager.CosmosDbTests/Fixtures/CosmosDbFixture.cs
+++ b/ChildAllowanceManager.CosmosDbTests/Fixtures/CosmosDbFixture.cs
@@ -1,0 +1,93 @@
+using Microsoft.Azure.Cosmos;
+using Microsoft.Azure.CosmosRepository;
+using Microsoft.Azure.CosmosRepository.AspNetCore.Extensions;
+using Microsoft.Azure.CosmosRepository.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Testcontainers.CosmosDb;
+
+namespace ChildAllowanceManager.CosmosDbTests.Fixtures;
+
+public class CosmosDbFixture
+{
+    private const string DatabaseId = "child-allowance-manager-tests";
+    private CosmosDbContainer _container = default!;
+    private CosmosClient _client = default!;
+    private IServiceProvider _serviceProvider = default!;
+
+    public bool IsAvailable { get; private set; } = true;
+    public string? SkipReason { get; private set; }
+
+    public IRepository<TItem> GetRepository<TItem>() where TItem : Item
+        => _serviceProvider.GetRequiredService<IRepository<TItem>>();
+
+    public async Task InitializeAsync()
+    {
+        try
+        {
+            _container = new CosmosDbBuilder().Build();
+            await _container.StartAsync();
+        }
+        catch (Exception ex) when (ex is Docker.DotNet.DockerApiException or DotNet.Testcontainers.Builders.DockerUnavailableException)
+        {
+            IsAvailable = false;
+            SkipReason = $"Docker is unavailable for Cosmos DB tests: {ex.Message}";
+            return;
+        }
+
+        _client = new CosmosClient(_container.GetConnectionString(), new CosmosClientOptions
+        {
+            SerializerOptions = new CosmosSerializationOptions
+            {
+                PropertyNamingPolicy = CosmosPropertyNamingPolicy.CamelCase
+            }
+        });
+
+        await _client.CreateDatabaseIfNotExistsAsync(DatabaseId);
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(_client);
+        services.AddCosmosRepository(options =>
+        {
+            options.CosmosConnectionString = _container.GetConnectionString();
+            options.DatabaseId = DatabaseId;
+            options.ContainerPerItemType = true;
+            options.AllowBulkExecution = true;
+            options.SerializationOptions = new RepositorySerializationOptions
+            {
+                PropertyNamingPolicy = CosmosPropertyNamingPolicy.CamelCase
+            };
+        });
+
+        _serviceProvider = services.BuildServiceProvider();
+    }
+
+    public async Task ResetAsync()
+    {
+        var database = _client.GetDatabase(DatabaseId);
+        try
+        {
+            await database.DeleteAsync();
+        }
+        catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            // database already removed
+        }
+
+        await _client.CreateDatabaseIfNotExistsAsync(DatabaseId);
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_serviceProvider is IAsyncDisposable asyncDisposable)
+        {
+            await asyncDisposable.DisposeAsync();
+        }
+
+        _client?.Dispose();
+        if (_container != null)
+        {
+            await _container.DisposeAsync();
+        }
+    }
+}

--- a/ChildAllowanceManager.CosmosDbTests/Services/TransactionServiceIntegrationTests.cs
+++ b/ChildAllowanceManager.CosmosDbTests/Services/TransactionServiceIntegrationTests.cs
@@ -1,0 +1,118 @@
+using ChildAllowanceManager.Common.Interfaces;
+using ChildAllowanceManager.Common.Models;
+using ChildAllowanceManager.CosmosDbTests.Fixtures;
+using ChildAllowanceManager.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Shouldly;
+
+namespace ChildAllowanceManager.CosmosDbTests.Services;
+
+[TestClass]
+public class TransactionServiceIntegrationTests
+{
+    private static readonly CosmosDbFixture Fixture = new();
+
+    [ClassInitialize]
+    public static async Task ClassInitialize(TestContext context)
+    {
+        await Fixture.InitializeAsync();
+    }
+
+    [ClassCleanup]
+    public static async Task ClassCleanup()
+    {
+        await Fixture.DisposeAsync();
+    }
+
+    [TestMethod]
+    public async Task AddTransaction_ComputesBalanceAndPersists()
+    {
+        if (!Fixture.IsAvailable)
+        {
+            Assert.Inconclusive(Fixture.SkipReason ?? "Docker is unavailable for Cosmos DB tests.");
+        }
+
+        await Fixture.ResetAsync();
+        var notificationMock = new Mock<IGlobalNotificationService>();
+        var repository = Fixture.GetRepository<AllowanceTransaction>();
+        var service = new TransactionService(repository, notificationMock.Object, NullLogger<TransactionService>.Instance);
+
+        var first = await service.AddTransaction(new AllowanceTransaction
+        {
+            ChildId = "child-1",
+            TenantId = "tenant-1",
+            TransactionAmount = 10m,
+            TransactionType = TransactionType.DailyAllowance,
+            Description = "Daily allowance"
+        });
+
+        var second = await service.AddTransaction(new AllowanceTransaction
+        {
+            ChildId = "child-1",
+            TenantId = "tenant-1",
+            TransactionAmount = -3m,
+            TransactionType = TransactionType.Withdrawal,
+            Description = "Purchase"
+        });
+
+        var transactions = await service.GetTransactionsForChild("child-1", "tenant-1");
+        transactions.Count().ShouldBe(2);
+
+        first.Balance.ShouldBe(10m);
+        second.Balance.ShouldBe(7m);
+        transactions.First().Id.ShouldBe(second.Id);
+        transactions.Last().Id.ShouldBe(first.Id);
+
+        notificationMock.Verify(n => n.OnChildStateChanged("child-1", "tenant-1",
+            It.Is<string>(s => s.Contains("Balance changed"))), Times.Exactly(2));
+    }
+
+    [TestMethod]
+    public async Task GetBalanceHistoryForChild_FillsMissingDays()
+    {
+        if (!Fixture.IsAvailable)
+        {
+            Assert.Inconclusive(Fixture.SkipReason ?? "Docker is unavailable for Cosmos DB tests.");
+        }
+
+        await Fixture.ResetAsync();
+        var repository = Fixture.GetRepository<AllowanceTransaction>();
+        var notificationMock = new Mock<IGlobalNotificationService>();
+        var service = new TransactionService(repository, notificationMock.Object, NullLogger<TransactionService>.Instance);
+
+        var startDate = DateTimeOffset.UtcNow.Date.AddDays(-2);
+        var middleDate = startDate.AddDays(1);
+
+        await repository.CreateAsync(new AllowanceTransaction
+        {
+            ChildId = "child-1",
+            TenantId = "tenant-1",
+            Balance = 5m,
+            TransactionAmount = 5m,
+            TransactionType = TransactionType.DailyAllowance,
+            Description = "Start",
+            TransactionTimestamp = startDate
+        });
+
+        await repository.CreateAsync(new AllowanceTransaction
+        {
+            ChildId = "child-1",
+            TenantId = "tenant-1",
+            Balance = 8m,
+            TransactionAmount = 3m,
+            TransactionType = TransactionType.DailyAllowance,
+            Description = "Middle",
+            TransactionTimestamp = middleDate
+        });
+
+        var history = (await service.GetBalanceHistoryForChild("child-1", "tenant-1",
+            startDate, startDate.AddDays(2), CancellationToken.None)).ToList();
+
+        history.Count.ShouldBe(3);
+        history[0].Balance.ShouldBe(5m);
+        history[1].Balance.ShouldBe(8m);
+        history[2].Balance.ShouldBe(8m);
+    }
+}

--- a/ChildAllowanceManager.UiTests/ChildAllowanceManager.UiTests.csproj
+++ b/ChildAllowanceManager.UiTests/ChildAllowanceManager.UiTests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AspNetCore.HealthChecks.CosmosDb" Version="8.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.Testing.Platform" Version="1.4.1" />
+    <PackageReference Include="Microsoft.Testing.Platform.MSBuild" Version="1.4.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
+    <PackageReference Include="bunit.web" Version="1.31.3" />
+    <PackageReference Include="Shouldly" Version="4.2.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ChildAllowanceManager\ChildAllowanceManager.csproj" />
+    <ProjectReference Include="..\ChildAllowanceManager.Common\ChildAllowanceManager.Common.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ChildAllowanceManager.UiTests/Components/ChildConfigurationEditorTests.cs
+++ b/ChildAllowanceManager.UiTests/Components/ChildConfigurationEditorTests.cs
@@ -1,0 +1,74 @@
+using Bunit;
+using ChildAllowanceManager.Common.Models;
+using ChildAllowanceManager.Components;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MudBlazor;
+using MudBlazor.Services;
+using Shouldly;
+
+namespace ChildAllowanceManager.UiTests.Components;
+
+[TestClass]
+public class ChildConfigurationEditorTests
+{
+    private Bunit.TestContext _context = default!;
+
+    [TestInitialize]
+    public void SetUp()
+    {
+        _context = new Bunit.TestContext();
+        _context.Services.AddMudServices();
+        _context.JSInterop.Mode = JSRuntimeMode.Loose;
+    }
+
+    [TestCleanup]
+    public void TearDown()
+    {
+        _context.Dispose();
+    }
+
+    [TestMethod]
+    public void RendersBirthdayAllowanceFieldWhenBirthDateProvided()
+    {
+        var child = new ChildConfiguration
+        {
+            FirstName = "Sam",
+            LastName = "Smith",
+            BirthDate = DateTime.Today
+        };
+
+        var cut = _context.Render(builder =>
+        {
+            builder.OpenComponent<MudPopoverProvider>(0);
+            builder.CloseComponent();
+            builder.OpenComponent<ChildConfigurationEditor>(1);
+            builder.AddAttribute(2, "Child", child);
+            builder.CloseComponent();
+        });
+
+        cut.FindComponents<MudNumericField<decimal?>>().Count.ShouldBe(1);
+        cut.FindComponents<MudNumericField<decimal>>().Count.ShouldBe(1);
+    }
+
+    [TestMethod]
+    public void DoesNotRenderBirthdayAllowanceFieldWhenBirthDateMissing()
+    {
+        var child = new ChildConfiguration
+        {
+            FirstName = "Sam",
+            LastName = "Smith"
+        };
+
+        var cut = _context.Render(builder =>
+        {
+            builder.OpenComponent<MudPopoverProvider>(0);
+            builder.CloseComponent();
+            builder.OpenComponent<ChildConfigurationEditor>(1);
+            builder.AddAttribute(2, "Child", child);
+            builder.CloseComponent();
+        });
+
+        cut.FindComponents<MudNumericField<decimal?>>().Count.ShouldBe(0);
+        cut.FindComponents<MudNumericField<decimal>>().Count.ShouldBe(1);
+    }
+}

--- a/ChildAllowanceManager.UnitTests/ChildAllowanceManager.UnitTests.csproj
+++ b/ChildAllowanceManager.UnitTests/ChildAllowanceManager.UnitTests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AspNetCore.HealthChecks.CosmosDb" Version="8.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.Testing.Platform" Version="1.4.1" />
+    <PackageReference Include="Microsoft.Testing.Platform.MSBuild" Version="1.4.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Shouldly" Version="4.2.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ChildAllowanceManager\ChildAllowanceManager.csproj" />
+    <ProjectReference Include="..\ChildAllowanceManager.Common\ChildAllowanceManager.Common.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ChildAllowanceManager.UnitTests/Notifications/GlobalNotificationServiceTests.cs
+++ b/ChildAllowanceManager.UnitTests/Notifications/GlobalNotificationServiceTests.cs
@@ -1,0 +1,31 @@
+using ChildAllowanceManager.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
+
+namespace ChildAllowanceManager.UnitTests.Notifications;
+
+[TestClass]
+public class GlobalNotificationServiceTests
+{
+    [TestMethod]
+    public void OnChildStateChanged_RaisesEventWithArguments()
+    {
+        var service = new GlobalNotificationService();
+        string? tenantId = null;
+        string? childId = null;
+        string? message = null;
+
+        service.ChildStateChanged += (_, args) =>
+        {
+            tenantId = args.TenantId;
+            childId = args.ChildId;
+            message = args.NotificationMessage;
+        };
+
+        service.OnChildStateChanged("child-1", "tenant-1", "updated");
+
+        tenantId.ShouldBe("tenant-1");
+        childId.ShouldBe("child-1");
+        message.ShouldBe("updated");
+    }
+}

--- a/ChildAllowanceManager.UnitTests/Notifications/TenantNotificationServiceTests.cs
+++ b/ChildAllowanceManager.UnitTests/Notifications/TenantNotificationServiceTests.cs
@@ -1,0 +1,38 @@
+using ChildAllowanceManager.Common.Interfaces;
+using ChildAllowanceManager.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Shouldly;
+
+namespace ChildAllowanceManager.UnitTests.Notifications;
+
+[TestClass]
+public class TenantNotificationServiceTests
+{
+    [TestMethod]
+    public void OnChildStateChanged_ShouldOnlyRaiseForCurrentTenant()
+    {
+        var currentContext = new Mock<ICurrentContextService>();
+        currentContext.Setup(c => c.GetCurrentTenant()).Returns("tenant-1");
+        var globalNotifications = new GlobalNotificationService();
+
+        var handlerInvoked = false;
+        using var service = new TenantNotificationService(currentContext.Object, globalNotifications,
+            NullLogger<TenantNotificationService>.Instance);
+
+        service.ChildStateChanged += (_, args) =>
+        {
+            handlerInvoked = true;
+            args.TenantId.ShouldBe("tenant-1");
+            args.ChildId.ShouldBe("child-1");
+        };
+
+        globalNotifications.OnChildStateChanged("child-1", "tenant-1", "message");
+        handlerInvoked.ShouldBeTrue();
+
+        handlerInvoked = false;
+        globalNotifications.OnChildStateChanged("child-1", "tenant-2", "message");
+        handlerInvoked.ShouldBeFalse();
+    }
+}

--- a/ChildAllowanceManager.UnitTests/Services/ChildServiceTests.cs
+++ b/ChildAllowanceManager.UnitTests/Services/ChildServiceTests.cs
@@ -1,0 +1,71 @@
+using System.Linq.Expressions;
+using ChildAllowanceManager.Common.Interfaces;
+using ChildAllowanceManager.Common.Models;
+using ChildAllowanceManager.Services;
+using Microsoft.Azure.CosmosRepository;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Shouldly;
+
+namespace ChildAllowanceManager.UnitTests.Services;
+
+[TestClass]
+public class ChildServiceTests
+{
+    [TestMethod]
+    public async Task GetChildrenWithBalance_ComputesNextRegularChangeWithHold()
+    {
+        var repoMock = new Mock<IRepository<ChildConfiguration>>();
+        var notifications = new Mock<IGlobalNotificationService>();
+        var transactionService = new Mock<ITransactionService>();
+
+        var child = new ChildConfiguration
+        {
+            Id = "child-1",
+            TenantId = "tenant-1",
+            FirstName = "Sam",
+            LastName = "Smith",
+            RegularAllowance = 2m,
+            HoldDaysRemaining = 2,
+            BirthDate = DateTime.UtcNow.Date
+        };
+
+        repoMock.Setup(r => r.GetAsync(It.IsAny<Expression<Func<ChildConfiguration, bool>>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { child });
+
+        transactionService.Setup(t => t.GetLatestTransactionForChild("child-1", "tenant-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AllowanceTransaction { Balance = 5m });
+        transactionService.Setup(t => t.GetLatestRegularTransactionForChild("child-1", "tenant-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AllowanceTransaction { TransactionTimestamp = DateTimeOffset.UtcNow.AddDays(-1) });
+
+        var service = new ChildService(new HttpClient(), repoMock.Object, notifications.Object,
+            transactionService.Object, NullLogger<ChildService>.Instance);
+
+        var result = (await service.GetChildrenWithBalance("tenant-1", default)).ToList();
+
+        result.Count.ShouldBe(1);
+        result[0].Balance.ShouldBe(5m);
+        result[0].NextRegularChange.ShouldBe(child.BirthdayAllowance ?? child.RegularAllowance);
+        result[0].NextRegularChangeDate.Date.ShouldBe(DateTimeOffset.UtcNow.AddDays(child.HoldDaysRemaining).Date);
+        result[0].IsBirthday.ShouldBeTrue();
+    }
+
+    [TestMethod]
+    public async Task DeleteChild_ReturnsFalseWhenMissing()
+    {
+        var repoMock = new Mock<IRepository<ChildConfiguration>>();
+        var notifications = new Mock<IGlobalNotificationService>();
+        var transactionService = new Mock<ITransactionService>();
+
+        repoMock.Setup(r => r.TryGetAsync("child-1", "tenant-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ChildConfiguration?)null);
+
+        var service = new ChildService(new HttpClient(), repoMock.Object, notifications.Object,
+            transactionService.Object, NullLogger<ChildService>.Instance);
+
+        var result = await service.DeleteChild("child-1", "tenant-1", default);
+
+        result.ShouldBeFalse();
+    }
+}

--- a/ChildAllowanceManager.UnitTests/Services/ClaimEnrichmentTransformerTests.cs
+++ b/ChildAllowanceManager.UnitTests/Services/ClaimEnrichmentTransformerTests.cs
@@ -1,0 +1,41 @@
+using System.Security.Claims;
+using ChildAllowanceManager.Common.Interfaces;
+using ChildAllowanceManager.Common.Models;
+using ChildAllowanceManager.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Shouldly;
+
+namespace ChildAllowanceManager.UnitTests.Services;
+
+[TestClass]
+public class ClaimEnrichmentTransformerTests
+{
+    [TestMethod]
+    public async Task TransformAsync_AddsMissingRoles()
+    {
+        var userService = new Mock<IUserService>();
+        userService.Setup(u => u.GetUserByEmailAsync("user@example.com", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new User
+            {
+                Email = "user@example.com",
+                Roles = new[] { ValidRoles.Admin, ValidRoles.Parent }
+            });
+
+        var identity = new ClaimsIdentity(new[]
+        {
+            new Claim(ClaimTypes.Email, "user@example.com"),
+            new Claim(ClaimTypes.Role, ValidRoles.Parent)
+        }, "mock");
+        var principal = new ClaimsPrincipal(identity);
+
+        var transformer = new ClaimEnrichmentTransformer(userService.Object,
+            NullLogger<ClaimEnrichmentTransformer>.Instance);
+
+        var result = await transformer.TransformAsync(principal);
+
+        result.Claims.ShouldContain(c => c.Type == ClaimTypes.Role && c.Value == ValidRoles.Admin);
+        result.Claims.Count(c => c.Type == ClaimTypes.Role && c.Value == ValidRoles.Parent).ShouldBe(1);
+    }
+}

--- a/ChildAllowanceManager.UnitTests/Services/CurrentContextServiceTests.cs
+++ b/ChildAllowanceManager.UnitTests/Services/CurrentContextServiceTests.cs
@@ -1,0 +1,27 @@
+using ChildAllowanceManager.Common.Interfaces;
+using ChildAllowanceManager.Common.Models;
+using ChildAllowanceManager.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Shouldly;
+
+namespace ChildAllowanceManager.UnitTests.Services;
+
+[TestClass]
+public class CurrentContextServiceTests
+{
+    [TestMethod]
+    public async Task GetCurrentTenantSuffix_ReturnsSuffixForCurrentTenant()
+    {
+        var tenantService = new Mock<ITenantService>();
+        tenantService.Setup(t => t.GetTenant("tenant-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TenantConfiguration { Id = "tenant-1", UrlSuffix = "house" });
+
+        var service = new CurrentContextService(tenantService.Object);
+        service.SetCurrentTenant("tenant-1");
+
+        var suffix = await service.GetCurrentTenantSuffix();
+
+        suffix.ShouldBe("house");
+    }
+}

--- a/ChildAllowanceManager.UnitTests/Services/TenantServiceTests.cs
+++ b/ChildAllowanceManager.UnitTests/Services/TenantServiceTests.cs
@@ -1,0 +1,47 @@
+using System.Linq.Expressions;
+using ChildAllowanceManager.Common.Interfaces;
+using ChildAllowanceManager.Common.Models;
+using ChildAllowanceManager.Services;
+using Microsoft.Azure.CosmosRepository;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Shouldly;
+
+namespace ChildAllowanceManager.UnitTests.Services;
+
+[TestClass]
+public class TenantServiceTests
+{
+    [TestMethod]
+    public async Task DeleteTenant_ShouldCascadeToChildrenAndUsers()
+    {
+        var tenantRepo = new Mock<IRepository<TenantConfiguration>>();
+        var userRepo = new Mock<IRepository<User>>();
+        var childService = new Mock<IChildService>();
+
+        var tenant = new TenantConfiguration { Id = "tenant-1" };
+        tenantRepo.Setup(r => r.TryGetAsync("tenant-1", null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tenant);
+
+        childService.Setup(c => c.GetChildren("tenant-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { new ChildConfiguration { Id = "child-1", TenantId = "tenant-1" } });
+
+        userRepo.Setup(r => r.GetAsync(It.IsAny<Expression<Func<User, bool>>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new User { Id = "user-1", Tenants = new[] { "tenant-1" } }
+            });
+
+        var service = new TenantService(tenantRepo.Object, userRepo.Object, childService.Object,
+            NullLogger<TenantService>.Instance);
+
+        var result = await service.DeleteTenant("tenant-1", default);
+
+        result.ShouldBeTrue();
+        tenant.Deleted.ShouldBeTrue();
+        childService.Verify(c => c.DeleteChild("child-1", "tenant-1", It.IsAny<CancellationToken>()), Times.Once);
+        userRepo.Verify(r => r.UpdateAsync(It.Is<User>(u => !u.Tenants.Contains("tenant-1")), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once);
+        tenantRepo.Verify(r => r.UpdateAsync(It.Is<TenantConfiguration>(t => t.Deleted), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/ChildAllowanceManager.UnitTests/Services/TransactionServiceTests.cs
+++ b/ChildAllowanceManager.UnitTests/Services/TransactionServiceTests.cs
@@ -1,0 +1,68 @@
+using ChildAllowanceManager.Common.Interfaces;
+using ChildAllowanceManager.Common.Models;
+using ChildAllowanceManager.Services;
+using Microsoft.Azure.CosmosRepository;
+using Microsoft.Azure.CosmosRepository.Specification;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Shouldly;
+
+namespace ChildAllowanceManager.UnitTests.Services;
+
+[TestClass]
+public class TransactionServiceTests
+{
+    [TestMethod]
+    public async Task GetBalanceForChild_ReturnsLatestBalance()
+    {
+        var repo = new Mock<IRepository<AllowanceTransaction>>();
+        var notifications = new Mock<IGlobalNotificationService>();
+
+        var queryResult = new Mock<IQueryResult<AllowanceTransaction>>();
+        queryResult.SetupGet(p => p.Items).Returns(new[]
+        {
+            new AllowanceTransaction { Balance = 12m, TransactionTimestamp = DateTimeOffset.UtcNow },
+            new AllowanceTransaction { Balance = 9m, TransactionTimestamp = DateTimeOffset.UtcNow.AddDays(-1) }
+        });
+
+        repo.Setup(r => r.QueryAsync(It.IsAny<ISpecification<AllowanceTransaction, IQueryResult<AllowanceTransaction>>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(queryResult.Object);
+
+        var service = new TransactionService(repo.Object, notifications.Object, NullLogger<TransactionService>.Instance);
+
+        var balance = await service.GetBalanceForChild("child-1", "tenant-1", default);
+
+        balance.ShouldBe(12m);
+    }
+
+    [TestMethod]
+    public async Task GetBalanceHistoryForChild_FillsMissingDays()
+    {
+        var repo = new Mock<IRepository<AllowanceTransaction>>();
+        var notifications = new Mock<IGlobalNotificationService>();
+
+        var start = DateTimeOffset.UtcNow.Date.AddDays(-2);
+        var middle = start.AddDays(1);
+        var end = start.AddDays(2);
+
+        var queryResult = new Mock<IQueryResult<AllowanceTransaction>>();
+        queryResult.SetupGet(p => p.Items).Returns(new[]
+        {
+            new AllowanceTransaction { TransactionTimestamp = start, Balance = 3m },
+            new AllowanceTransaction { TransactionTimestamp = middle, Balance = 6m }
+        });
+
+        repo.Setup(r => r.QueryAsync(It.IsAny<ISpecification<AllowanceTransaction, IQueryResult<AllowanceTransaction>>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(queryResult.Object);
+
+        var service = new TransactionService(repo.Object, notifications.Object, NullLogger<TransactionService>.Instance);
+
+        var result = (await service.GetBalanceHistoryForChild("child-1", "tenant-1", start, end, default)).ToList();
+
+        result.Count.ShouldBe(3);
+        result[0].Balance.ShouldBe(3m);
+        result[1].Balance.ShouldBe(6m);
+        result[2].Balance.ShouldBe(6m);
+    }
+}

--- a/ChildAllowanceManager.UnitTests/Services/UserServiceTests.cs
+++ b/ChildAllowanceManager.UnitTests/Services/UserServiceTests.cs
@@ -1,0 +1,61 @@
+using System.Linq.Expressions;
+using ChildAllowanceManager.Common.Models;
+using ChildAllowanceManager.Services;
+using Microsoft.Azure.CosmosRepository;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Shouldly;
+
+namespace ChildAllowanceManager.UnitTests.Services;
+
+[TestClass]
+public class UserServiceTests
+{
+    [TestMethod]
+    public async Task InitializeUserAsync_FirstUserGetsAdminRole()
+    {
+        var repo = new Mock<IRepository<User>>();
+        repo.Setup(r => r.CountAsync(It.IsAny<Expression<Func<User, bool>>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0);
+        repo.Setup(r => r.GetAsync(It.IsAny<Expression<Func<User, bool>>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<User>());
+        repo.Setup(r => r.CreateAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((User u, CancellationToken _) => u);
+
+        var service = new UserService(repo.Object, NullLogger<UserService>.Instance);
+
+        var user = await service.InitializeUserAsync("first@example.com", "First User", "tenant-1", default);
+
+        user.Roles.ShouldContain(ValidRoles.Admin);
+        user.Tenants.ShouldContain("tenant-1");
+    }
+
+    [TestMethod]
+    public async Task AddUserToTenantAsync_UpdatesExistingUser()
+    {
+        var repo = new Mock<IRepository<User>>();
+        var existing = new User
+        {
+            Id = "user-1",
+            Email = "user@example.com",
+            Name = "Original",
+            Roles = new[] { ValidRoles.Parent },
+            Tenants = new[] { "tenant-1" }
+        };
+
+        repo.Setup(r => r.GetAsync(It.IsAny<Expression<Func<User, bool>>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { existing });
+        repo.Setup(r => r.UpdateAsync(It.IsAny<User>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((User u, bool _, CancellationToken _) => u);
+
+        var service = new UserService(repo.Object, NullLogger<UserService>.Instance);
+
+        var result = await service.AddUserToTenantAsync("user@example.com", "Updated", "tenant-2", ValidRoles.Admin, default);
+
+        result.ShouldBeTrue();
+        existing.Tenants.ShouldContain("tenant-2");
+        existing.Roles.ShouldContain(ValidRoles.Admin);
+        existing.Name.ShouldBe("Updated");
+    }
+}

--- a/ChildAllowanceManager.UnitTests/Validators/ChildConfigurationValidatorTests.cs
+++ b/ChildAllowanceManager.UnitTests/Validators/ChildConfigurationValidatorTests.cs
@@ -1,0 +1,28 @@
+using ChildAllowanceManager.Common.Models;
+using ChildAllowanceManager.Common.Validators;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
+
+namespace ChildAllowanceManager.UnitTests.Validators;
+
+[TestClass]
+public class ChildConfigurationValidatorTests
+{
+    [TestMethod]
+    public void Validator_FailsForFutureBirthDate()
+    {
+        var validator = new ChildConfigurationValidator();
+        var child = new ChildConfiguration
+        {
+            FirstName = "Sam",
+            LastName = "Smith",
+            BirthDate = DateTime.Today.AddDays(1),
+            RegularAllowance = 1m
+        };
+
+        var result = validator.Validate(child);
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain(e => e.ErrorMessage.Contains("future"));
+    }
+}

--- a/ChildAllowanceManager.UnitTests/Validators/TenantConfigurationValidatorTests.cs
+++ b/ChildAllowanceManager.UnitTests/Validators/TenantConfigurationValidatorTests.cs
@@ -1,0 +1,27 @@
+using ChildAllowanceManager.Common.Models;
+using ChildAllowanceManager.Common.Validators;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
+
+namespace ChildAllowanceManager.UnitTests.Validators;
+
+[TestClass]
+public class TenantConfigurationValidatorTests
+{
+    [TestMethod]
+    public void Validator_FailsForShortName()
+    {
+        var validator = new TenantConfigurationValidator();
+        var tenant = new TenantConfiguration
+        {
+            TenantName = "abc",
+            UrlSuffix = "def"
+        };
+
+        var result = validator.Validate(tenant);
+
+        result.IsValid.ShouldBeFalse();
+        result.Errors.ShouldContain(e => e.PropertyName == nameof(TenantConfiguration.TenantName));
+        result.Errors.ShouldContain(e => e.PropertyName == nameof(TenantConfiguration.UrlSuffix));
+    }
+}

--- a/ChildAllowanceManager.sln
+++ b/ChildAllowanceManager.sln
@@ -4,6 +4,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChildAllowanceManager", "Ch
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChildAllowanceManager.Common", "ChildAllowanceManager.Common\ChildAllowanceManager.Common.csproj", "{5998504A-D8CB-4969-B903-EE789537D7AD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChildAllowanceManager.UnitTests", "ChildAllowanceManager.UnitTests\ChildAllowanceManager.UnitTests.csproj", "{616D2D5D-8069-4A86-AEFF-54B720178D2B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChildAllowanceManager.UiTests", "ChildAllowanceManager.UiTests\ChildAllowanceManager.UiTests.csproj", "{A4E4B5B1-ED25-4C6B-9D77-1716D1AEA59F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChildAllowanceManager.CosmosDbTests", "ChildAllowanceManager.CosmosDbTests\ChildAllowanceManager.CosmosDbTests.csproj", "{B5A66149-AE3C-4673-B858-8933AF867DEA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -18,5 +24,17 @@ Global
 		{5998504A-D8CB-4969-B903-EE789537D7AD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5998504A-D8CB-4969-B903-EE789537D7AD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5998504A-D8CB-4969-B903-EE789537D7AD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{616D2D5D-8069-4A86-AEFF-54B720178D2B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{616D2D5D-8069-4A86-AEFF-54B720178D2B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{616D2D5D-8069-4A86-AEFF-54B720178D2B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{616D2D5D-8069-4A86-AEFF-54B720178D2B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A4E4B5B1-ED25-4C6B-9D77-1716D1AEA59F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A4E4B5B1-ED25-4C6B-9D77-1716D1AEA59F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A4E4B5B1-ED25-4C6B-9D77-1716D1AEA59F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A4E4B5B1-ED25-4C6B-9D77-1716D1AEA59F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B5A66149-AE3C-4673-B858-8933AF867DEA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B5A66149-AE3C-4673-B858-8933AF867DEA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B5A66149-AE3C-4673-B858-8933AF867DEA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B5A66149-AE3C-4673-B858-8933AF867DEA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
### Motivation
- Provide clearer separation between fast unit tests, Blazor UI tests, and Cosmos DB integration tests to make CI runs deterministic and Docker-independent.
- Use Microsoft.Testing.Platform and MSTest across test projects while replacing FluentAssertions with `Shouldly` for assertions.
- Add bUnit-based component tests for frontend logic and ensure coverlet collects coverage for unit-level verification.
- Make Cosmos DB integration tests idempotent and runtime-skippable when Docker/Testcontainers are unavailable.

### Description
- Split the original test project into three projects: `ChildAllowanceManager.UnitTests`, `ChildAllowanceManager.UiTests` (bUnit), and `ChildAllowanceManager.CosmosDbTests` (Testcontainers), and updated the solution file to include them.
- Switched assertion library to `Shouldly`, added `Microsoft.Testing.Platform`/`Microsoft.NET.Test.Sdk` and `coverlet.collector` to test projects, and set test project properties (`IsTestProject`, `CopyLocalLockFileAssemblies`) for reliable test execution.
- Added a `CosmosDbFixture` that starts a Testcontainers Cosmos DB instance, configures `Microsoft.Azure.CosmosRepository` serialization options, and exposes `IsAvailable`/`SkipReason` so integration tests can be marked inconclusive when Docker is unavailable.
- Added unit tests for services/validators/notifications, bUnit tests for `ChildConfigurationEditor` with MudBlazor setup and JSInterop handling, and Cosmos integration tests that are skipped at runtime if the emulator cannot be started.

### Testing
- Ran `dotnet test ChildAllowanceManager.UnitTests/ChildAllowanceManager.UnitTests.csproj` with coverlet thresholds and the unit suite completed successfully (all tests passed and coverage threshold satisfied).
- Ran `dotnet test ChildAllowanceManager.UiTests/ChildAllowanceManager.UiTests.csproj` with coverlet and the bUnit component tests passed.
- Ran `dotnet test ChildAllowanceManager.CosmosDbTests/ChildAllowanceManager.CosmosDbTests.csproj` and the Cosmos tests were detected and skipped at runtime when Docker/Testcontainers were unavailable.
- All automated test runs completed with no failing tests in unit/UI suites and Cosmos DB tests marked inconclusive/skipped when the environment could not start a container.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dbd137554832abdf400b488f32753)